### PR TITLE
refactor: remove unnecessary type casting in toJson method

### DIFF
--- a/lib/data/models/api_responses/get_document_types.dart
+++ b/lib/data/models/api_responses/get_document_types.dart
@@ -33,7 +33,7 @@ class GetDocumentTypes {
       'titleResponse': titleResponse,
       'textResponse': textResponse,
       'lastAction': lastAction,
-      'data': data?.map((e) => (e as Document).toJson()).toList(),
+      'data': data?.map((e) => (e).toJson()).toList(),
     };
   }
 }


### PR DESCRIPTION
The type casting `(e as Document)` was redundant since `e` is already of type `Document`. This change simplifies the code without altering its behavior.